### PR TITLE
fix: make sure library deps are defined as 'dependencies' in package.json

### DIFF
--- a/libs/keypair/project.json
+++ b/libs/keypair/project.json
@@ -6,6 +6,7 @@
       "executor": "@nrwl/js:tsc",
       "outputs": ["{options.outputPath}"],
       "options": {
+        "buildableProjectDepsInPackageJsonType": "dependencies",
         "outputPath": "dist/libs/keypair",
         "tsConfig": "libs/keypair/tsconfig.lib.json",
         "packageJson": "libs/keypair/package.json",

--- a/libs/sdk/project.json
+++ b/libs/sdk/project.json
@@ -6,6 +6,7 @@
       "executor": "@nrwl/js:tsc",
       "outputs": ["{options.outputPath}"],
       "options": {
+        "buildableProjectDepsInPackageJsonType": "dependencies",
         "outputPath": "dist/libs/sdk",
         "tsConfig": "libs/sdk/tsconfig.lib.json",
         "packageJson": "libs/sdk/package.json",

--- a/libs/solana/project.json
+++ b/libs/solana/project.json
@@ -6,6 +6,7 @@
       "executor": "@nrwl/js:tsc",
       "outputs": ["{options.outputPath}"],
       "options": {
+        "buildableProjectDepsInPackageJsonType": "dependencies",
         "outputPath": "dist/libs/solana",
         "tsConfig": "libs/solana/tsconfig.lib.json",
         "packageJson": "libs/solana/package.json",


### PR DESCRIPTION
[Currently](https://unpkg.com/browse/@mogami/sdk@1.0.0-beta.1/package.json), the dependencies of our libraries are added to the `peerDependencies`, making installation harder than needed as we need to list all of the dependencies as installation instructions.

With this patch, they will be added to the `dependencies` object which will make the installation and instructions easier.



