### PR TITLE
feat: add admin ui tabs component for routed tabs

### DIFF
--- a/libs/admin/app/feature/src/lib/admin-app-feature-detail.tsx
+++ b/libs/admin/app/feature/src/lib/admin-app-feature-detail.tsx
@@ -1,6 +1,7 @@
-import { Box, Stack, Tab, TabList, TabPanel, TabPanels, Tabs, useToast } from '@chakra-ui/react'
+import { Box, Stack, useToast } from '@chakra-ui/react'
 import { AdminAppUiForm, AdminAppUiUserModal, AdminAppUiUsers } from '@mogami/admin/app/ui'
 import { AdminUiLoader } from '@mogami/admin/ui/loader'
+import { AdminUiTabs } from '@mogami/admin/ui/tabs'
 import {
   AppUpdateInput,
   AppUserAddInput,
@@ -11,7 +12,7 @@ import {
   useUpdateAppMutation,
 } from '@mogami/shared/util/admin-sdk'
 import React from 'react'
-import { useParams } from 'react-router-dom'
+import { Redirect, Route, Switch, useParams, useRouteMatch } from 'react-router-dom'
 import { AppEnvironmentsTab } from './app-environments-tab'
 import { AppHeader } from './app-header'
 
@@ -50,6 +51,12 @@ export default function AdminAppFeatureDetail() {
     }
     return res?.data?.updated
   }
+  const { path, url } = useRouteMatch()
+  const tabs = [
+    { path: `${url}/environments`, label: 'Environments' },
+    { path: `${url}/users`, label: 'Users' },
+    { path: `${url}/settings`, label: 'Settings' },
+  ]
 
   const addRole = async ({ role, userId }: AppUserAddInput) => {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -71,29 +78,40 @@ export default function AdminAppFeatureDetail() {
   return (
     <Stack direction="column" spacing={6}>
       <AppHeader app={data?.item} />
-      <Tabs isLazy colorScheme="teal">
-        <TabList>
-          <Tab>Environments</Tab>
-          <Tab>Users</Tab>
-          <Tab>Settings</Tab>
-        </TabList>
-        <TabPanels>
-          <TabPanel>{appId && <AppEnvironmentsTab appId={appId} />}</TabPanel>
-          <TabPanel>
-            <Stack direction="column" spacing={6}>
-              <Box w="full">
-                <AdminAppUiUsers updateRole={updateRole} users={data?.item?.users} />
-              </Box>
-              <Box>
-                <AdminAppUiUserModal addRole={addRole} />
-              </Box>
-            </Stack>
-          </TabPanel>
-          <TabPanel>
-            <AdminAppUiForm app={data?.item} onSubmit={onSubmit} />
-          </TabPanel>
-        </TabPanels>
-      </Tabs>
+      <Switch>
+        <Route path={path} exact render={() => <Redirect to={`${url}/environments`} />} />
+        <Route
+          path={`${path}/environments`}
+          render={() => (
+            <AdminUiTabs tabs={tabs}>
+              <AppEnvironmentsTab appId={appId} />
+            </AdminUiTabs>
+          )}
+        />
+        <Route
+          path={`${path}/users`}
+          render={() => (
+            <AdminUiTabs tabs={tabs}>
+              <Stack direction="column" spacing={6}>
+                <Box w="full">
+                  <AdminAppUiUsers updateRole={updateRole} users={data?.item?.users} />
+                </Box>
+                <Box>
+                  <AdminAppUiUserModal addRole={addRole} />
+                </Box>
+              </Stack>
+            </AdminUiTabs>
+          )}
+        />
+        <Route
+          path={`${path}/settings`}
+          render={() => (
+            <AdminUiTabs tabs={tabs}>
+              <AdminAppUiForm app={data?.item} onSubmit={onSubmit} />
+            </AdminUiTabs>
+          )}
+        />
+      </Switch>
     </Stack>
   )
 }

--- a/libs/admin/app/feature/src/lib/admin-app-feature.tsx
+++ b/libs/admin/app/feature/src/lib/admin-app-feature.tsx
@@ -11,8 +11,8 @@ export function AdminAppFeature() {
     <React.Suspense fallback={<AdminUiLoader />}>
       <Switch>
         <Route path="/apps" exact render={() => <AdminAppFeatureList />} />
-        <Route path="/apps/:appId" exact render={() => <AdminAppFeatureDetail />} />
         <Route path="/apps/:appId/environments/:appEnvId" render={() => <AdminAppFeatureEnvDetail />} />
+        <Route path="/apps/:appId" render={() => <AdminAppFeatureDetail />} />
       </Switch>
     </React.Suspense>
   )

--- a/libs/admin/app/feature/src/lib/env-detail-layout.tsx
+++ b/libs/admin/app/feature/src/lib/env-detail-layout.tsx
@@ -1,14 +1,12 @@
-import { Box, Flex, Stack, Tab, TabList, Tabs } from '@chakra-ui/react'
+import { Box, Flex, Stack } from '@chakra-ui/react'
 import { AdminClusterUiCluster } from '@mogami/admin/cluster/ui'
+import { AdminUiTabs } from '@mogami/admin/ui/tabs'
 import React, { PropsWithChildren } from 'react'
-import { Link, useRouteMatch } from 'react-router-dom'
 import { useAppEnv } from './app-env-provider'
 import { AppHeader } from './app-header'
 
 export function EnvDetailLayout({ children }: PropsWithChildren<any>) {
   const { appEnv, tabs } = useAppEnv()
-  const { url } = useRouteMatch()
-  const defaultIndex = tabs.findIndex((item) => url.startsWith(item.path)) || 0
   return (
     <Stack direction="column" spacing={6}>
       {appEnv.app && <AppHeader app={appEnv.app} />}
@@ -20,16 +18,7 @@ export function EnvDetailLayout({ children }: PropsWithChildren<any>) {
           {appEnv?.cluster && <AdminClusterUiCluster cluster={appEnv?.cluster} />}
         </Flex>
       </Box>
-      <Tabs colorScheme="teal" defaultIndex={defaultIndex}>
-        <TabList>
-          {tabs.map((tab) => (
-            <Tab as={Link} key={tab.path} to={tab.path}>
-              {tab.label}
-            </Tab>
-          ))}
-        </TabList>
-      </Tabs>
-      <Box>{children}</Box>
+      <AdminUiTabs tabs={tabs}>{children}</AdminUiTabs>
     </Stack>
   )
 }

--- a/libs/admin/cluster/feature/src/lib/admin-cluster-feature-detail.tsx
+++ b/libs/admin/cluster/feature/src/lib/admin-cluster-feature-detail.tsx
@@ -1,13 +1,15 @@
-import { Box, Flex, Image, Stack, Tab, TabList, TabPanel, TabPanels, Tabs } from '@chakra-ui/react'
+import { Box, Flex, Image, Stack } from '@chakra-ui/react'
 import { AdminUiLoader } from '@mogami/admin/ui/loader'
+import { AdminUiTabs } from '@mogami/admin/ui/tabs'
 import { useClusterQuery } from '@mogami/shared/util/admin-sdk'
 import React from 'react'
-import { useParams } from 'react-router-dom'
+import { Redirect, Route, Switch, useParams, useRouteMatch } from 'react-router-dom'
 import { AdminClusterFeatureMintsTab } from './admin-cluster-feature-mints-tab'
 import { AdminClusterFeatureSettingsTab } from './admin-cluster-feature-settings-tab'
 import { AdminClusterFeatureStatsTab } from './admin-cluster-feature-stats-tab'
 
 export default function AdminClusterFeatureDetail() {
+  const { path, url } = useRouteMatch()
   const { clusterId } = useParams<{ clusterId: string }>()
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const [{ data, fetching }] = useClusterQuery({ variables: { clusterId: clusterId! } })
@@ -15,7 +17,11 @@ export default function AdminClusterFeatureDetail() {
   if (!data || fetching) {
     return <AdminUiLoader />
   }
-
+  const tabs = [
+    { path: `${url}/mints`, label: 'Mints' },
+    { path: `${url}/stats`, label: 'Stats' },
+    { path: `${url}/settings`, label: 'Settings' },
+  ]
   return (
     <Stack direction="column" spacing={6}>
       <Box p="6" borderWidth="1px" borderRadius="lg" overflow="hidden">
@@ -28,19 +34,29 @@ export default function AdminClusterFeatureDetail() {
           </Box>
         </Flex>
       </Box>
-
-      <Tabs isLazy colorScheme="teal">
-        <TabList>
-          <Tab>Mints</Tab>
-          <Tab>Stats</Tab>
-          <Tab>Settings</Tab>
-        </TabList>
-        <TabPanels>
-          <TabPanel>{clusterId && <AdminClusterFeatureMintsTab clusterId={clusterId} />}</TabPanel>
-          <TabPanel>{clusterId && <AdminClusterFeatureStatsTab clusterId={clusterId} />}</TabPanel>
-          <TabPanel>{clusterId && <AdminClusterFeatureSettingsTab clusterId={clusterId} />}</TabPanel>
-        </TabPanels>
-      </Tabs>
+      <Switch>
+        <Route path={path} exact render={() => <Redirect to={`${url}/mints`} />} />
+        <Route
+          path={`${path}/mints`}
+          render={() => (
+            <AdminUiTabs tabs={tabs}>{clusterId && <AdminClusterFeatureMintsTab clusterId={clusterId} />}</AdminUiTabs>
+          )}
+        />
+        <Route
+          path={`${path}/stats`}
+          render={() => (
+            <AdminUiTabs tabs={tabs}>{clusterId && <AdminClusterFeatureStatsTab clusterId={clusterId} />}</AdminUiTabs>
+          )}
+        />
+        <Route
+          path={`${path}/settings`}
+          render={() => (
+            <AdminUiTabs tabs={tabs}>
+              {clusterId && <AdminClusterFeatureSettingsTab clusterId={clusterId} />}
+            </AdminUiTabs>
+          )}
+        />
+      </Switch>
     </Stack>
   )
 }

--- a/libs/admin/cluster/feature/src/lib/admin-cluster-feature.tsx
+++ b/libs/admin/cluster/feature/src/lib/admin-cluster-feature.tsx
@@ -10,7 +10,7 @@ export function AdminClusterFeature() {
     <React.Suspense fallback={<AdminUiLoader />}>
       <Switch>
         <Route path="/clusters" exact render={() => <AdminClusterFeatureList />} />
-        <Route path="/clusters/:clusterId" exact render={() => <AdminClusterFeatureDetail />} />
+        <Route path="/clusters/:clusterId" render={() => <AdminClusterFeatureDetail />} />
       </Switch>
     </React.Suspense>
   )

--- a/libs/admin/cluster/ui/src/lib/admin-cluster-ui-form.tsx
+++ b/libs/admin/cluster/ui/src/lib/admin-cluster-ui-form.tsx
@@ -30,7 +30,7 @@ const fields: UiFormField[] = [
 
 export function AdminClusterUiForm({ cluster, onSubmit }: AdminClusterUiProps) {
   return (
-    <Box borderWidth="1px" rounded="lg" p={6} m="10px auto">
+    <Box borderWidth="1px" rounded="lg" p={6}>
       <Stack direction="column" spacing={6}>
         <Box mt="1" fontWeight="semibold" fontSize="xl" as="h4" lineHeight="tight" isTruncated flex={'auto'}>
           Cluster settings

--- a/libs/admin/ui/tabs/.babelrc
+++ b/libs/admin/ui/tabs/.babelrc
@@ -1,0 +1,12 @@
+{
+  "presets": [
+    [
+      "@nrwl/react/babel",
+      {
+        "runtime": "automatic",
+        "useBuiltIns": "usage"
+      }
+    ]
+  ],
+  "plugins": []
+}

--- a/libs/admin/ui/tabs/.eslintrc.json
+++ b/libs/admin/ui/tabs/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["plugin:@nrwl/nx/react", "../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/admin/ui/tabs/README.md
+++ b/libs/admin/ui/tabs/README.md
@@ -1,0 +1,7 @@
+# admin-ui-tabs
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test admin-ui-tabs` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/admin/ui/tabs/jest.config.ts
+++ b/libs/admin/ui/tabs/jest.config.ts
@@ -1,0 +1,10 @@
+/* eslint-disable */
+export default {
+  displayName: 'admin-ui-tabs',
+  preset: '../../../../jest.preset.js',
+  transform: {
+    '^.+\\.[tj]sx?$': 'babel-jest',
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../../../coverage/libs/admin/ui/tabs',
+}

--- a/libs/admin/ui/tabs/project.json
+++ b/libs/admin/ui/tabs/project.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/admin/ui/tabs/src",
+  "projectType": "library",
+  "tags": ["type:ui", "scope:admin"],
+  "targets": {
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["libs/admin/ui/tabs/**/*.{ts,tsx,js,jsx}"]
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["coverage/libs/admin/ui/tabs"],
+      "options": {
+        "jestConfig": "libs/admin/ui/tabs/jest.config.ts",
+        "passWithNoTests": true
+      }
+    }
+  }
+}

--- a/libs/admin/ui/tabs/src/index.ts
+++ b/libs/admin/ui/tabs/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/admin-ui-tabs'

--- a/libs/admin/ui/tabs/src/lib/admin-ui-tabs.spec.tsx
+++ b/libs/admin/ui/tabs/src/lib/admin-ui-tabs.spec.tsx
@@ -1,0 +1,10 @@
+import { render } from '@testing-library/react'
+
+import AdminUiTabs from './admin-ui-tabs'
+
+describe('AdminUiTabs', () => {
+  it('should render successfully', () => {
+    const { baseElement } = render(<AdminUiTabs />)
+    expect(baseElement).toBeTruthy()
+  })
+})

--- a/libs/admin/ui/tabs/src/lib/admin-ui-tabs.spec.tsx
+++ b/libs/admin/ui/tabs/src/lib/admin-ui-tabs.spec.tsx
@@ -1,10 +1,17 @@
 import { render } from '@testing-library/react'
+import { BrowserRouter } from 'react-router-dom'
 
-import AdminUiTabs from './admin-ui-tabs'
+import { AdminUiTabs } from './admin-ui-tabs'
 
 describe('AdminUiTabs', () => {
   it('should render successfully', () => {
-    const { baseElement } = render(<AdminUiTabs />)
+    const { baseElement } = render(
+      <BrowserRouter>
+        <AdminUiTabs tabs={[]}>
+          <div>Hi</div>
+        </AdminUiTabs>
+      </BrowserRouter>,
+    )
     expect(baseElement).toBeTruthy()
   })
 })

--- a/libs/admin/ui/tabs/src/lib/admin-ui-tabs.tsx
+++ b/libs/admin/ui/tabs/src/lib/admin-ui-tabs.tsx
@@ -1,0 +1,26 @@
+import { Box, Stack, Tab, TabList, Tabs } from '@chakra-ui/react'
+import React, { PropsWithChildren } from 'react'
+import { Link, useRouteMatch } from 'react-router-dom'
+
+export interface AdminUiTabsProps {
+  tabs: { path: string; label: string }[]
+}
+
+export function AdminUiTabs({ children, tabs }: PropsWithChildren<AdminUiTabsProps>) {
+  const { url } = useRouteMatch()
+  const defaultIndex = tabs.findIndex((item) => url.startsWith(item.path)) || 0
+  return (
+    <Stack direction="column" spacing={6}>
+      <Tabs colorScheme="teal" defaultIndex={defaultIndex}>
+        <TabList>
+          {tabs.map((tab) => (
+            <Tab as={Link} key={tab.path} to={tab.path}>
+              {tab.label}
+            </Tab>
+          ))}
+        </TabList>
+      </Tabs>
+      <Box>{children}</Box>
+    </Stack>
+  )
+}

--- a/libs/admin/ui/tabs/tsconfig.json
+++ b/libs/admin/ui/tabs/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "allowJs": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/admin/ui/tabs/tsconfig.lib.json
+++ b/libs/admin/ui/tabs/tsconfig.lib.json
@@ -1,0 +1,23 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "types": ["node"]
+  },
+  "files": [
+    "../../../../node_modules/@nrwl/react/typings/cssmodule.d.ts",
+    "../../../../node_modules/@nrwl/react/typings/image.d.ts"
+  ],
+  "exclude": [
+    "jest.config.ts",
+    "**/*.spec.ts",
+    "**/*.test.ts",
+    "**/*.spec.tsx",
+    "**/*.test.tsx",
+    "**/*.spec.js",
+    "**/*.test.js",
+    "**/*.spec.jsx",
+    "**/*.test.jsx"
+  ],
+  "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
+}

--- a/libs/admin/ui/tabs/tsconfig.spec.json
+++ b/libs/admin/ui/tabs/tsconfig.spec.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.test.tsx",
+    "**/*.spec.tsx",
+    "**/*.test.js",
+    "**/*.spec.js",
+    "**/*.test.jsx",
+    "**/*.spec.jsx",
+    "**/*.d.ts"
+  ]
+}

--- a/libs/admin/user/feature/src/lib/admin-user-feature-detail.tsx
+++ b/libs/admin/user/feature/src/lib/admin-user-feature-detail.tsx
@@ -1,11 +1,13 @@
-import { Box, Stack, Tab, TabList, TabPanel, TabPanels, Tabs, useToast } from '@chakra-ui/react'
+import { Box, Stack, useToast } from '@chakra-ui/react'
+import { AdminUiTabs } from '@mogami/admin/ui/tabs'
 import { AdminUserUiApps, AdminUserUiEmails, AdminUserUiForm } from '@mogami/admin/user/ui'
 import { UserUpdateInput, useUpdateUserMutation, useUserQuery } from '@mogami/shared/util/admin-sdk'
 import React from 'react'
-import { useParams } from 'react-router-dom'
+import { Redirect, Route, Switch, useParams, useRouteMatch } from 'react-router-dom'
 
 export default function AdminUserFeatureDetail() {
   const toast = useToast()
+  const { path, url } = useRouteMatch()
   const { userId } = useParams<{ userId: string }>()
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const [{ data }] = useUserQuery({ variables: { userId: userId! } })
@@ -20,7 +22,11 @@ export default function AdminUserFeatureDetail() {
     }
     return res?.data?.updated
   }
-
+  const tabs = [
+    { path: `${url}/apps`, label: 'Apps' },
+    { path: `${url}/emails`, label: 'Emails' },
+    { path: `${url}/settings`, label: 'Settings' },
+  ]
   return (
     <Stack direction="column" spacing={6}>
       <Box p="6" borderWidth="1px" borderRadius="lg" overflow="hidden">
@@ -28,25 +34,33 @@ export default function AdminUserFeatureDetail() {
           {data?.item?.name}
         </Box>
       </Box>
-
-      <Tabs isLazy colorScheme="teal">
-        <TabList>
-          <Tab>Apps</Tab>
-          <Tab>Emails</Tab>
-          <Tab>Settings</Tab>
-        </TabList>
-        <TabPanels>
-          <TabPanel>
-            <AdminUserUiApps apps={data?.item?.apps} />
-          </TabPanel>
-          <TabPanel>
-            <AdminUserUiEmails emails={data?.item?.emails} />
-          </TabPanel>
-          <TabPanel>
-            <AdminUserUiForm user={data?.item} onSubmit={onSubmit} />
-          </TabPanel>
-        </TabPanels>
-      </Tabs>
+      <Switch>
+        <Route path={path} exact render={() => <Redirect to={`${url}/apps`} />} />
+        <Route
+          path={`${path}/apps`}
+          render={() => (
+            <AdminUiTabs tabs={tabs}>
+              <AdminUserUiApps apps={data?.item?.apps} />
+            </AdminUiTabs>
+          )}
+        />
+        <Route
+          path={`${path}/emails`}
+          render={() => (
+            <AdminUiTabs tabs={tabs}>
+              <AdminUserUiEmails emails={data?.item?.emails} />
+            </AdminUiTabs>
+          )}
+        />
+        <Route
+          path={`${path}/settings`}
+          render={() => (
+            <AdminUiTabs tabs={tabs}>
+              <AdminUserUiForm user={data?.item} onSubmit={onSubmit} />
+            </AdminUiTabs>
+          )}
+        />
+      </Switch>
     </Stack>
   )
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -29,6 +29,7 @@
       "@mogami/admin/ui/form": ["libs/admin/ui/form/src/index.ts"],
       "@mogami/admin/ui/layout": ["libs/admin/ui/layout/src/index.ts"],
       "@mogami/admin/ui/loader": ["libs/admin/ui/loader/src/index.ts"],
+      "@mogami/admin/ui/tabs": ["libs/admin/ui/tabs/src/index.ts"],
       "@mogami/admin/user/feature": ["libs/admin/user/feature/src/index.ts"],
       "@mogami/admin/user/ui": ["libs/admin/user/ui/src/index.ts"],
       "@mogami/airdrop": ["libs/airdrop/src/index.ts"],

--- a/workspace.json
+++ b/workspace.json
@@ -16,6 +16,7 @@
     "admin-ui-form": "libs/admin/ui/form",
     "admin-ui-layout": "libs/admin/ui/layout",
     "admin-ui-loader": "libs/admin/ui/loader",
+    "admin-ui-tabs": "libs/admin/ui/tabs",
     "admin-user-feature": "libs/admin/user/feature",
     "admin-user-ui": "libs/admin/user/ui",
     "airdrop": "libs/airdrop",


### PR DESCRIPTION
This PR adds the `AdminUiTabs` component for easy use of tabbed routes:

```tsx
function Cmp() {
  const { path, url } = useRouteMatch()
  const tabs = [
    { path: `${url}/environments`, label: 'Environments' },
    { path: `${url}/settings`, label: 'Settings' },
  ]
  return <Switch>
    <Route path={path} exact render={() => <Redirect to={`${url}/environments`} />} />
    <Route
      path={`${path}/environments`}
      render={() => (
        <AdminUiTabs tabs={tabs}>
          <AppEnvironmentsTab appId={appId} />
        </AdminUiTabs>
      )}
    />
    <Route
      path={`${path}/settings`}
      render={() => (
        <AdminUiTabs tabs={tabs}>
          <AdminAppUiForm app={data?.item} onSubmit={onSubmit} />
        </AdminUiTabs>
      )}
    />
  </Switch>
}

```